### PR TITLE
feat: added CI for build/update application container image

### DIFF
--- a/.github/workflows/build_app_image.yaml
+++ b/.github/workflows/build_app_image.yaml
@@ -1,0 +1,28 @@
+name: Build App Image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build_and_ship:
+    name: Build & Ship OCI image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # References:
+      # - https://github.com/mamezou-tech/buildpacks-action
+      # - https://github.com/marketplace/actions/buildpacks-action
+      - name: Invoke buildpacks-action
+        uses: mamezou-tech/buildpacks-action@master
+        with:
+          image: 'ghcr.io/hwakabh/bennu-official/django'
+          tag: 'latest'
+          builder: 'paketobuildpacks/builder-jammy-full'
+          # TODO: should be fetched from .python-version
+          env: 'BP_CPYTHON_VERSION=3.11.5'
+          publish: true


### PR DESCRIPTION
# Issue link
Closes #40 

# What does this PR do?
- Added gh-actions with [buildpacks-action](https://github.com/mamezou-tech/buildpacks-action)

# What does not include in this PR?
- Dynamically fetch `BP_CPYTHON_VERSION` from `.python-version` in code bases
  - This will be handled in https://github.com/hwakabh/bennu-official/issues/46)
- Local testings with gh-actions before merging into main, meaning we checked with e2e, where image would be updated in GHCR, only after merging this PR