### PR TITLE
fix(ci): added docker login actions.

### DIFF
--- a/.github/workflows/build_app_image.yaml
+++ b/.github/workflows/build_app_image.yaml
@@ -14,6 +14,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PUSH_PAT }}
+
       # References:
       # - https://github.com/mamezou-tech/buildpacks-action
       # - https://github.com/marketplace/actions/buildpacks-action


### PR DESCRIPTION
# Issue link
Closes #47 

# What does this PR do?
- Add [docker login actions](https://github.com/docker/login-action)
- Add GitHub PAT as Repository Secret `GHCR_PUSH_PAT` in Settings menu

# What does not include in this PR?
Local testings with gh-actions before merging into main, meaning we checked with e2e, where image would be updated in GHCR, only after merging this PR
