### PR TITLE
fix(ci): replaced token from PAT to GitHub CI Token.

### DIFF
--- a/.github/workflows/build_app_image.yaml
+++ b/.github/workflows/build_app_image.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PUSH_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # References:
       # - https://github.com/mamezou-tech/buildpacks-action


### PR DESCRIPTION
# Issue link
Closes #47 

# What does this PR do?
- Replaced token used by gh-action from repository secret to `GITHUB_TOKEN`

# What does not include in this PR?
N/A
