### PR TITLE
fix running buildpacks on CI with GHCR

### DIFF
--- a/.github/workflows/build_app_image.yaml
+++ b/.github/workflows/build_app_image.yaml
@@ -29,7 +29,8 @@ jobs:
         with:
           image: 'ghcr.io/hwakabh/bennu-official/django'
           tag: 'latest'
-          builder: 'paketobuildpacks/builder-jammy-full'
+          builder: 'paketobuildpacks/builder:full'
+          # buildpacks: 'paketo-buildpacks/python'
           # TODO: should be fetched from .python-version
           env: 'BP_CPYTHON_VERSION=3.11.5'
           publish: true

--- a/.github/workflows/build_app_image.yaml
+++ b/.github/workflows/build_app_image.yaml
@@ -2,8 +2,8 @@ name: Build App Image
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
   workflow_dispatch:
 
 jobs:
@@ -32,4 +32,5 @@ jobs:
           builder: 'paketobuildpacks/builder-jammy-full'
           # TODO: should be fetched from .python-version
           env: 'BP_CPYTHON_VERSION=3.11.5'
+          debug_mode: "true"
           publish: true

--- a/.github/workflows/build_app_image.yaml
+++ b/.github/workflows/build_app_image.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PUSH_TOKEN }}
 
       # References:
       # - https://github.com/mamezou-tech/buildpacks-action

--- a/.github/workflows/build_app_image.yaml
+++ b/.github/workflows/build_app_image.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_SECRET }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # References:
       # - https://github.com/mamezou-tech/buildpacks-action

--- a/.github/workflows/build_app_image.yaml
+++ b/.github/workflows/build_app_image.yaml
@@ -2,8 +2,8 @@ name: Build App Image
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_app_image.yaml
+++ b/.github/workflows/build_app_image.yaml
@@ -17,9 +17,9 @@ jobs:
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io/hwakabh/bennu-official/django
+          registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PUSH_TOKEN }}
+          password: ${{ secrets.GITHUB_SECRET }}
 
       # References:
       # - https://github.com/mamezou-tech/buildpacks-action

--- a/.github/workflows/build_app_image.yaml
+++ b/.github/workflows/build_app_image.yaml
@@ -19,18 +19,18 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PUSH_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        # https://github.com/docker/login-action#github-container-registry
 
-      # References:
-      # - https://github.com/mamezou-tech/buildpacks-action
-      # - https://github.com/marketplace/actions/buildpacks-action
-      - name: Invoke buildpacks-action
-        uses: mamezou-tech/buildpacks-action@master
-        with:
-          image: 'ghcr.io/hwakabh/bennu-official/django'
-          tag: 'latest'
-          builder: 'paketobuildpacks/builder:full'
-          # buildpacks: 'paketo-buildpacks/python'
-          # TODO: should be fetched from .python-version
-          env: 'BP_CPYTHON_VERSION=3.11.5'
-          publish: true
+      - name: Install pack
+        uses: buildpacks/github-actions/setup-pack@v5.0.0
+        # https://github.com/buildpacks/github-actions#setup-pack-cli-action
+
+      - name: Publish packages
+        run: |
+          pack build ghcr.io/hwakabh/bennu-official:latest \
+            --builder paketobuildpacks/builder-jammy-full \
+            --buildpack paketo-buildpacks/python \
+            --path . \
+            --env "$(cat .python-version)" \
+            --publish

--- a/.github/workflows/build_app_image.yaml
+++ b/.github/workflows/build_app_image.yaml
@@ -17,9 +17,9 @@ jobs:
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ghcr.io/hwakabh/bennu-official/django
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PUSH_TOKEN }}
 
       # References:
       # - https://github.com/mamezou-tech/buildpacks-action
@@ -32,5 +32,4 @@ jobs:
           builder: 'paketobuildpacks/builder-jammy-full'
           # TODO: should be fetched from .python-version
           env: 'BP_CPYTHON_VERSION=3.11.5'
-          debug_mode: "true"
           publish: true


### PR DESCRIPTION
# Issue link
Closes: #47 
Relates: #40, #46 

# What does this PR do?
- Remove [buildpack-actions](https://github.com/mamezou-tech/buildpacks-action) and separate them with [setup-pack](https://github.com/buildpacks/github-actions#setup-pack-cli-action) and scratched step with `run:`
  - This is because we could not provide docker credentials for buildpack-actions with `--publish` options
  - Also for continuous maintenance, it would be much better to use the one by [official](https://github.com/buildpacks), instead of 3rd party personal one
- Enable to fetch `.python-version` with `run:` comand (#46)
- Enable to specify which buildpack to use
  - Currently we only use [paketo-buildpacks/python](https://github.com/paketo-buildpacks/python), and this makes CI more faster

# What does not include in this PR?
Finalize pipeline