### PR TITLE
fix warnings of release-please

### DIFF
--- a/.github/workflows/release_please.yaml
+++ b/.github/workflows/release_please.yaml
@@ -16,6 +16,3 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         with:
           release-type: python
-          # https://github.com/google-github-actions/release-please-action/issues/396#issuecomment-1136479955
-          package-name: bennu-official
-          version-path: bennu_official/__init__.py


### PR DESCRIPTION
# Issue link
Relates #65 

# What does this PR do?
- Removed `package-name` and `version-path` from release-please-action config

# What does not include in this PR?
N/A
