### PR TITLE
fix: provide staticfiles with gunicorn (production)

### DIFF
--- a/bennu_official/settings.py
+++ b/bennu_official/settings.py
@@ -19,16 +19,17 @@ INSTALLED_APPS = [
     'bennuhp',
 ]
 
+# Strict order for whitenoise
+# https://whitenoise.readthedocs.io/en/stable/django.html#enable-whitenoise
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
-    'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
 ]
 
 ROOT_URLCONF = 'bennu_official.urls'


### PR DESCRIPTION
# Issue link
Relates #78 

# What does this PR do?
- Changed order of MIDDLEWARES since whitenoise requires to strict order

# What does not include in this PR?
e2e testings with build artifacts