### PR TITLE
perf: changed worker_class to gthread from sync, default.

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -11,6 +11,7 @@ raw_env = []
 bind = '0.0.0.0:8000'
 
 # Worker Processes
+worker_class = 'gthread'
 workers = 2
 threads = 8
 keepalive = 0


### PR DESCRIPTION
# Issue link
Relates #114 

# What does this PR do?
- Added `worker_class` parameter to change from `sync` (default) to `gthread`

# What does not include in this PR?
e2e testings with build artifacts