### PR TITLE
fix(ci): added envars of MinIO for runnings tests.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,11 +11,12 @@ env:
   # For starting up bitnami/mysql
   MYSQL_ROOT_PASSWORD: root
   MYSQL_DATABASE: bennu
+  # For starting up bitnami/minio
+  MINIO_ROOT_USER: minioadmin
+  MINIO_ROOT_PASSWORD: minio123
   # Additionally for Django container
   MYSQL_HOSTNAME: 127.0.0.1
   MYSQL_USER: root
-  MINIO_ROOT_USER: minioadmin
-  MINIO_ROOT_PASSWORD: minio123
   MINIO_STORAGE_ENDPOINT: localhost:9000
   MINIO_STORAGE_ACCESS_KEY: minioadmin
   MINIO_STORAGE_SECRET_KEY: minio123
@@ -69,6 +70,8 @@ jobs:
           MYSQL_ROOT_PASSWORD: ${{ env.MYSQL_ROOT_PASSWORD }}
           MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
           MYSQL_USER: ${{ env.MYSQL_USER }}
+          MINIO_STORAGE_ENDPOING: ${{ env.MINIO_STORAGE_ENDPOINT }}
+          MINIO_STORAGE_ACCESS_KEY: ${{ env.MINIO_STORAGE_ACCESS_KEY }}
+          MINIO_STORAGE_SECRET_KEY: ${{ env.MINIO_STORAGE_SECRET_KEY }}
         run: |
-          env
           python manage.py test --debug-mode -v 2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,9 @@ env:
   # Additionally for Django container
   MYSQL_HOSTNAME: 127.0.0.1
   MYSQL_USER: root
+  MINIO_STORAGE_ENDPOINT: localhost:9000
+  MINIO_STORAGE_ACCESS_KEY: minioadmin
+  MINIO_STORAGE_SECRET_KEY: minio123
 
 jobs:
   tests:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,14 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      minio:
+        image: bitnami/minio:latest
+        ports:
+          - 9000:9000
+        env:
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minio123
+          MINIO_DEFAULT_BUCKETS: bennu:public
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,8 @@ env:
   # Additionally for Django container
   MYSQL_HOSTNAME: 127.0.0.1
   MYSQL_USER: root
+  MINIO_ROOT_USER: minioadmin
+  MINIO_ROOT_PASSWORD: minio123
   MINIO_STORAGE_ENDPOINT: localhost:9000
   MINIO_STORAGE_ACCESS_KEY: minioadmin
   MINIO_STORAGE_SECRET_KEY: minio123
@@ -41,8 +43,8 @@ jobs:
         ports:
           - 9000:9000
         env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minio123
+          MINIO_ROOT_USER: ${{ env.MINIO_ROOT_USER }}
+          MINIO_ROOT_PASSWORD: ${{ env.MINIO_ROOT_PASSWORD }}
           MINIO_DEFAULT_BUCKETS: bennu:public
 
     steps:
@@ -68,4 +70,5 @@ jobs:
           MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
           MYSQL_USER: ${{ env.MYSQL_USER }}
         run: |
+          env
           python manage.py test --debug-mode -v 2

--- a/bennu_official/settings.py
+++ b/bennu_official/settings.py
@@ -110,8 +110,7 @@ STATICFILES_DIRS = (
 # - destination path of ./manage.py collectstatic
 STATIC_ROOT = os.path.join(BASE_DIR, 'assets')
 # - URL path of staticfiles, which is specified at templates in Pod by buildpacks
-# STATIC_URL = '/workspace/assets/'
-# STATIC_URL = '/assets/'
+STATIC_URL = '/workspace/assets/'
 
 
 MINIO_STORAGE_ENDPOINT = os.environ.get('MINIO_STORAGE_ENDPOINT')

--- a/compose.yaml
+++ b/compose.yaml
@@ -32,7 +32,10 @@ services:
     volumes:
       - staticfiles:/workspace/assets
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
 
   mysql:
     image: bitnami/mysql:latest
@@ -44,9 +47,34 @@ services:
     ports:
       - 3306:3306
     tty: true
+    healthcheck:
+      test: "mysqladmin ping || exit 1"
+      interval: 3s
+      retries: 3
     volumes:
       - mysql-data:/opt/bitnami/mysql/data
+
+  minio:
+    image: bitnami/minio:latest
+    container_name: minio
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minio123
+      MINIO_DEFAULT_BUCKETS: bennu:public
+    ports:
+      - 9000:9000
+      - 9001:9001
+    volumes:
+      - minio-data:/bitnami/minio/data
+    healthcheck:
+      test: "mc ping local --count 1 || exit 1"
+      interval: 3s
+      retries: 3
+    deploy:
+      restart_policy:
+        condition: on-failure
 
 volumes:
   staticfiles:
   mysql-data:
+  minio-data:


### PR DESCRIPTION
# Issue link
Closes #128 

# What does this PR do?
- Added environmental variables related to MinIO in CI
- Enabled `STATIC_URL` again for passing test CI
  - on local environment, `STATIC_URL` is overridden with `/assets/` by `local_settings.py`
  - on production, `STATIC_URL` is not required because staticfiles are served by MinIO and this will defined in `MINIO_STORAGE_ENDPOINT` with django-minio-storage package
  - but in CI we have to set `STATIC_URL` so that activate this
- Added compose jobs of MinIO server with using `bitnami/minio`
- Added healthcheck to MySQL and MinIO for waiting startup to avoid connection refused from client-side

# What does not include in this PR?
N/A