### PR TITLE
fix(deploy): fixed collectstatic configurations

### DIFF
--- a/manifests/configs/nginx.conf
+++ b/manifests/configs/nginx.conf
@@ -22,6 +22,6 @@ server {
 
   # Configured in settings.py with Django
   location /assets/ {
-    root /usr/share/nginx/html;
+    root /usr/share/nginx;
   }
 }

--- a/manifests/django.yaml
+++ b/manifests/django.yaml
@@ -18,13 +18,6 @@ spec:
         app: bennu
     spec:
       initContainers:
-      # - image: ghcr.io/hwakabh/bennu-official:latest
-      #   name: collectstatic
-      #   command:
-      #   - /cnb/process/collectstatic
-      #   envFrom:
-      #     - secretRef:
-      #         name: app-secret
       - image: ghcr.io/hwakabh/bennu-official:latest
         name: migrate
         command:
@@ -50,6 +43,14 @@ spec:
         volumeMounts:
         - mountPath: /workspace/assets
           name: static
+        # Need for collectstatic to RWX shared volumes
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 0
+        lifecycle:
+          postStart:
+            exec:
+              command: ['/cnb/process/collectstatic']
         readinessProbe:
           httpGet:
             path: /healthz

--- a/manifests/nginx.yaml
+++ b/manifests/nginx.yaml
@@ -24,7 +24,7 @@ spec:
         volumeMounts:
         - mountPath: /opt/bitnami/nginx/conf/server_blocks
           name: nginx-conf
-        - mountPath: /usr/share/nginx/html
+        - mountPath: /usr/share/nginx/assets
           name: static
       volumes:
       - name: nginx-conf
@@ -48,4 +48,4 @@ spec:
     targetPort: 8443
   selector:
     app: bennu
-  type: ClusterIP
+  type: LoadBalancer


### PR DESCRIPTION
# Issue link
Relates #82 

# What does this PR do?
- Fixed directory path of `collectstatic` target in nginx.conf
- Modified collectstatic initContainer as postStart lifecycle
- Fixed serviceType of NGINX deployment (Ref: [comment](https://github.com/hwakabh/bennu-official/issues/82#issuecomment-1918795380))
- Added root permission to Django container for executing `/cnb/process/collectstatic` towards shared RWX volumes with NGINX Pod

# What does not include in this PR?
Performance tuning, which is managed in #114 