### PR TITLE
fix(ci): changed token-type from github-token to PAT.

### DIFF
--- a/.github/workflows/scheduled_image_cleanup.yaml
+++ b/.github/workflows/scheduled_image_cleanup.yaml
@@ -19,5 +19,4 @@ jobs:
           # Keep 1 image within 1 days ago
           keep-at-least: 1
           account-type: personal
-          token-type: github-token
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_PACKAGE_CLEANUP }}


### PR DESCRIPTION
# Issue link
Relates #141 

# What does this PR do?
- Updated `token-type` to use GitHub PAT
- Generated PAT `package-cleanup` whose scope is `package:read` and `package:delete`
- Added Repository Secret for passing PAT to CI

# What does not include in this PR?
e2e testings, since the changes will be applied with reading configurations from default branch, and this requires to merge this PR into `main`.