### PR TITLE
build: added cert-manager issuer and enabled TLS with it

### DIFF
--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -4,15 +4,18 @@ kind: Ingress
 metadata:
   name: bennu-app
   namespace: bennuhp
+  annotations:
+    cert-manager.io/issuer: "letsencrypt"
 spec:
+  tls:
+    - hosts:
+        - bennu-official.page
+      # cert-manager automatically generate secret
+      secretName: tls-cert
   ingressClassName: "nginx"
-  defaultBackend:
-    service:
-      name: nginx
-      port:
-        number: 80
   rules:
-  - http:
+  - host: bennu-official.page
+    http:
       paths:
       - pathType: Prefix
         path: "/"

--- a/manifests/issuer.yaml
+++ b/manifests/issuer.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt
+  namespace: bennuhp
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: 'hrykwkbys1024@gmail.com'
+    # cert-manager automatically generate secret
+    privateKeySecretRef:
+      name: ca-letsencrypt
+    solvers:
+      - http01:
+          ingress:
+            class: nginx


### PR DESCRIPTION
# Issue link
Relates #164 

# What does this PR do?
- added issuer resource of Let's Encrypt, whose ACME challenge method for custom domain is HTTP-01
- added ingress resource associated to cert-manager issuer

# What does not include in this PR?
- installation of ingress-nginx controller to GKE cluster, since it have already done in #134.
- installation of cert-manager, since we have [already installed manually with `helm`](https://github.com/hwakabh/bennu-official/issues/164#issuecomment-1973220840) commands, and it does expect to use helm chart instead of plain manifests.