### PR TITLE
perf: added more specific labels and controls with LabelSelector

### DIFF
--- a/manifests/django.yaml
+++ b/manifests/django.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   labels:
     app: bennu
+    tier: app
   name: django
   namespace: bennuhp
 spec:
@@ -11,11 +12,13 @@ spec:
   selector:
     matchLabels:
       app: bennu
+      tier: app
   strategy: {}
   template:
     metadata:
       labels:
         app: bennu
+        tier: app
     spec:
       initContainers:
       - image: ghcr.io/hwakabh/bennu-official:latest
@@ -70,6 +73,7 @@ kind: Service
 metadata:
   labels:
     app: bennu
+    tier: app
   name: django
   namespace: bennuhp
 spec:
@@ -79,4 +83,5 @@ spec:
     targetPort: 8000
   selector:
     app: bennu
+    tier: app
   type: ClusterIP

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - ./sealed-secrets.yaml
   - ./nfs-server.yaml
   - ./staticfiles.yaml
-  # - ./mysql.yaml
+  - ./mysql.yaml
   - ./django.yaml
   - ./nginx.yaml
   - ./ingress.yaml
@@ -14,6 +14,7 @@ configMapGenerator:
   - name: nginx-etc
     files:
       - ./configs/nginx.conf
+# tiers of web/app/db have all 3 replicas as default
 replicas:
   - name: django
     count: 1

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -2,13 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: bennuhp
 resources:
-  # - ./controllers/sealed-secret-controller.yaml
-  - ./controllers/ingress-nginx-controller.yaml
   - ./namespace.yaml
   - ./sealed-secrets.yaml
   - ./nfs-server.yaml
   - ./staticfiles.yaml
-  - ./mysql.yaml
+  # - ./mysql.yaml
   - ./django.yaml
   - ./nginx.yaml
   - ./ingress.yaml
@@ -17,5 +15,5 @@ configMapGenerator:
     files:
       - ./configs/nginx.conf
 replicas:
-  - name: ingress-nginx-controller
-    count: 3
+  - name: django
+    count: 1

--- a/manifests/mysql.yaml
+++ b/manifests/mysql.yaml
@@ -4,6 +4,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: bennu
+    tier: db
   name: mysql
   namespace: bennuhp
 spec:
@@ -11,11 +12,13 @@ spec:
   selector:
     matchLabels:
       app: bennu
+      tier: db
   serviceName: mysql
   template:
     metadata:
       labels:
         app: bennu
+        tier: db
     spec:
       containers:
       - name: mysql
@@ -36,6 +39,7 @@ spec:
       namespace: bennu
       labels:
         app: bennu
+        tier: db
     spec:
       storageClassName: standard-rwo
       accessModes:
@@ -52,6 +56,7 @@ metadata:
   namespace: bennuhp
   labels:
     app: bennu
+    tier: db
 spec:
   ports:
   - port: 3306
@@ -59,4 +64,5 @@ spec:
     targetPort: 3306
   selector:
     app: bennu
+    tier: db
   clusterIP: None

--- a/manifests/nginx.yaml
+++ b/manifests/nginx.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   labels:
     app: bennu
+    tier: web
   name: nginx
   namespace: bennuhp
 spec:
@@ -11,11 +12,13 @@ spec:
   selector:
     matchLabels:
       app: bennu
+      tier: web
   strategy: {}
   template:
     metadata:
       labels:
         app: bennu
+        tier: web
     spec:
       containers:
       - image: bitnami/nginx:latest
@@ -39,6 +42,7 @@ kind: Service
 metadata:
   labels:
     app: bennu
+    tier: web
   name: nginx
   namespace: bennuhp
   # annotations:
@@ -51,4 +55,5 @@ spec:
     targetPort: 8443
   selector:
     app: bennu
+    tier: web
   type: ClusterIP


### PR DESCRIPTION
# Issue link
Closes: #114 

# What does this PR do?
- added labels to workloads in order to determine destination Pods identically
- updated conditions of LabelSelector, where we define them with the field `spec.selector` in manifests of Service resources
- removed kustomizations entries for other namespaces from `resources` field, since it will trigger conflict errors on applying manifests with kustomization

# What does not include in this PR?
- update labels of nfs-server from `role: nfs-server` to `tier: nfs` as well as other Pods, since labels are immutable and we should not destroy them for now