### PR TITLE
perf(build): enhanced routing from nginx to django

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,4 +5,4 @@ Relates #
 # What does this PR do?
 
 
-# What does not include in this PR?
+# (Optional) Additional Contexts or Justifications

--- a/manifests/configs/nginx.conf
+++ b/manifests/configs/nginx.conf
@@ -23,5 +23,6 @@ server {
   # Configured in settings.py with Django
   location /assets/ {
     root /usr/share/nginx;
+    expires 1d;
   }
 }

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -14,7 +14,3 @@ configMapGenerator:
   - name: nginx-etc
     files:
       - ./configs/nginx.conf
-# tiers of web/app/db have all 3 replicas as default
-replicas:
-  - name: django
-    count: 1


### PR DESCRIPTION
# Issue link
Relates #177 

# What does this PR do?
- removed `replicas` overrides of django from kustomization, for enforcing its number of pods 3
- added `expires: 1d` to `nginx.conf` for caching static files on nginx Pods
- updated PR templates

# What does not include in this PR?
kustomization has been already applied to GKE cluster, so that we need not to consider GitOps solutions to apply changes in this PR for now.