### PR TITLE
refactor: docker compose

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -47,7 +47,7 @@ services:
     tty: true
     healthcheck:
       test: "mysqladmin ping || exit 1"
-      interval: 3s
+      interval: 5s
       retries: 3
     volumes:
       - mysql-data:/opt/bitnami/mysql/data

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 x-environment: &mysql_environments
   MYSQL_ROOT_PASSWORD: root
   MYSQL_DATABASE: bennu


### PR DESCRIPTION
# Issue link
Closes #193

# What does this PR do?
- removed `version` field from `compose.yaml`
- modified `interval` time from 3s to 5s for waiting MySQL container starting up.

# (Optional) Additional Contexts or Justifications
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted the health check interval for a service from 3 seconds to 5 seconds to improve health monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->