### PR TITLE
refactor: root URL path for top page

### DIFF
--- a/bennuhp/urls.py
+++ b/bennuhp/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import re_path
 from django.conf import settings
 from django.conf.urls.static import static
 
@@ -9,11 +9,11 @@ from . import views
 app_name = 'bennuhp'
 
 urlpatterns = [
-    path('healthz', views.HealthzView.as_view(), name='healthz'),
-    path('biography/', views.BioTemplateView.as_view(), name='bio'),
-    path('discography/', views.DiscoListView.as_view(), name='disco'),
-    path('lives/', views.LivesListView.as_view(), name='live'),
-    path('', views.AppRootTemplateView.as_view(), name='root'),
+    re_path('healthz', views.HealthzView.as_view(), name='healthz'),
+    re_path('biography/', views.BioTemplateView.as_view(), name='bio'),
+    re_path('discography/', views.DiscoListView.as_view(), name='disco'),
+    re_path('lives/', views.LivesListView.as_view(), name='live'),
+    re_path(r'^$', views.AppRootTemplateView.as_view(), name='root'),
 ]
 
 if settings.DEBUG:

--- a/bennuhp/urls.py
+++ b/bennuhp/urls.py
@@ -10,10 +10,10 @@ app_name = 'bennuhp'
 
 urlpatterns = [
     path('healthz', views.HealthzView.as_view(), name='healthz'),
-    path('home/', views.AppRootTemplateView.as_view(), name='root'),
     path('biography/', views.BioTemplateView.as_view(), name='bio'),
     path('discography/', views.DiscoListView.as_view(), name='disco'),
     path('lives/', views.LivesListView.as_view(), name='live'),
+    path('', views.AppRootTemplateView.as_view(), name='root'),
 ]
 
 if settings.DEBUG:

--- a/tests/bennuhp/test_views.py
+++ b/tests/bennuhp/test_views.py
@@ -16,11 +16,11 @@ class TestsRoutesStatusCode(TestCase):
         pass
 
     def test_healthz_success(self):
-        resp = self.client.get('/home/')
+        resp = self.client.get('/healthz/')
         self.assertEqual(resp.status_code, 200)
 
     def test_home_success(self):
-        resp = self.client.get('/home/')
+        resp = self.client.get('/')
         self.assertEqual(resp.status_code, 200)
 
     def test_bio_success(self):


### PR DESCRIPTION
# Issue link
Closes #165 

# What does this PR do?
- modified URL patterns from `/home` to `/` as fallback path
- fixed target URL of `/healthz` in test cases
- updated test cases for URL changes
- replaced `django.urls.path` with `django.urls.re_path` for fallback path

# (Optional) Additional Contexts or Justifications
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the root URL to display the home page by default.
  
- **Improvements**
  - Adjusted health check interval from 3 seconds to 5 seconds for improved service monitoring.

- **Tests**
  - Updated test cases to reflect the new URL mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->