### PR TITLE
feat(deploy): added default values for local developments.

### DIFF
--- a/bennu_official/settings.py
+++ b/bennu_official/settings.py
@@ -60,10 +60,10 @@ pymysql.install_as_MySQLdb()
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': os.environ.get('MYSQL_DATABASE'),
-        'USER': os.environ.get('MYSQL_USER'),
-        'PASSWORD': os.environ.get('MYSQL_ROOT_PASSWORD'),
-        'HOST': os.environ.get('MYSQL_HOSTNAME'),
+        'NAME': os.environ.get('MYSQL_DATABASE', 'bennu'),
+        'USER': os.environ.get('MYSQL_USER', 'root'),
+        'PASSWORD': os.environ.get('MYSQL_ROOT_PASSWORD', 'root'),
+        'HOST': os.environ.get('MYSQL_HOSTNAME', 'localhost'),
         'PORT': '3306',
     }
 }


### PR DESCRIPTION
## Issue link
closes: #196 

## What does this PR do?
- added default values to `settings.py`, which would be set when no environmental variables provided.

## (Optional) Additional Contexts or Justifications
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added default values for database connection parameters, improving usability for development and testing environments by ensuring the application can connect to a MySQL database with sensible defaults.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->