### PR TITLE
fix(deploy): updated volume-nfs images.

### DIFF
--- a/manifests/nfs-server.yaml
+++ b/manifests/nfs-server.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
       - name: nfs-server
-        image: gcr.io/google_containers/volume-nfs:latest
+        image: gcr.io/google-containers/volume-nfs:latest
         ports:
         - name: nfs
           containerPort: 2049


### PR DESCRIPTION
## Issue link
closes: #202 

## What does this PR do?
- fixed with proper container image of NFS server from `google_containers` to `google-containers`

## (Optional) Additional Contexts or Justifications
The changes of this PR is including e2e testings of keel.sh as mentioned in PR #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the image name format for the NFS server container to align with standard naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->